### PR TITLE
fix: don't include width and height if set to 0

### DIFF
--- a/.changeset/serious-hotels-love.md
+++ b/.changeset/serious-hotels-love.md
@@ -1,0 +1,5 @@
+---
+'@graphcms/rich-text-react-renderer': patch
+---
+
+Make sure width and height are not included if set to 0

--- a/examples/content-example.ts
+++ b/examples/content-example.ts
@@ -7,6 +7,20 @@ export const content: RichTextContent = {
       children: [{ text: 'Awesome new GraphCMS cap!' }],
     },
     {
+      src: 'https://media.graphassets.com/bFyCrmvuQfO7n0l5ZmH5',
+      type: 'image',
+      title: 'logo.svg',
+      width: 0,
+      handle: 'mQeGmwkXTnqTfcgUXVr7',
+      height: 0,
+      children: [
+        {
+          text: '',
+        },
+      ],
+      mimeType: 'image/svg+xml',
+    },
+    {
       type: 'paragraph',
       children: [
         { text: 'Sweet black ' },

--- a/packages/html-renderer/test/index.test.ts
+++ b/packages/html-renderer/test/index.test.ts
@@ -212,6 +212,31 @@ describe('@graphcms/rich-text-html-renderer', () => {
   `);
   });
 
+  it('removes the width and height attributes if they are set to 0', () => {
+    const html = astToHtmlString({
+      content: [
+        {
+          src: 'https://media.graphassets.com/bFyCrmvuQfO7n0l5ZmH5',
+          type: 'image',
+          title: 'logo.svg',
+          width: 0,
+          handle: 'mQeGmwkXTnqTfcgUXVr7',
+          height: 0,
+          children: [
+            {
+              text: '',
+            },
+          ],
+          mimeType: 'image/svg+xml',
+        },
+      ],
+    });
+
+    expect(html).toEqual(`
+    <img loading="lazy" src="https://media.graphassets.com/bFyCrmvuQfO7n0l5ZmH5"    title="logo.svg" />
+  `);
+  });
+
   it('renders image with custom renderer', () => {
     const html = astToHtmlString({
       content: iframeContent,

--- a/packages/react-renderer/src/elements/Image.tsx
+++ b/packages/react-renderer/src/elements/Image.tsx
@@ -15,12 +15,15 @@ export function Image({
     );
   }
 
+  const shouldIncludeWidth = width && width > 0;
+  const shouldIncludeHeight = height && height > 0;
+
   return (
     <img
       loading="lazy"
       src={escapeHtml(src)}
-      width={width}
-      height={height}
+      {...(shouldIncludeWidth && { width })}
+      {...(shouldIncludeHeight && { height })}
       alt={altText}
       title={title}
     />

--- a/packages/react-renderer/test/RichText.test.tsx
+++ b/packages/react-renderer/test/RichText.test.tsx
@@ -325,6 +325,39 @@ describe('@graphcms/rich-text-react-renderer', () => {
     `);
   });
 
+  it('removes the width and height attributes if they are set to 0', () => {
+    const { container } = render(
+      <RichText
+        content={[
+          {
+            src: 'https://media.graphassets.com/bFyCrmvuQfO7n0l5ZmH5',
+            type: 'image',
+            title: 'logo.svg',
+            width: 0,
+            handle: 'mQeGmwkXTnqTfcgUXVr7',
+            height: 0,
+            children: [
+              {
+                text: '',
+              },
+            ],
+            mimeType: 'image/svg+xml',
+          },
+        ]}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <img
+          loading="lazy"
+          src="https://media.graphassets.com/bFyCrmvuQfO7n0l5ZmH5"
+          title="logo.svg"
+        />
+      </div>
+    `);
+  });
+
   it('renders image with custom renderer', () => {
     const { container } = render(
       <RichText


### PR DESCRIPTION
This fix is related to an issue that usually happens with SVG. When an SVG is saved, GraphCMS can't set its dimensions, so the width and height of the SVG file are set to 0. So when rendering it, the image will be hidden because the width/height is set to 0. This PR makes sure we only add the width and height attributes if they are bigger than 0. Since the SVG usually has a width and height defined in its document, it will be rendered using its size.