### PR TITLE
Update index.ts openInNewTab value

### DIFF
--- a/packages/html-to-slate-ast/src/index.ts
+++ b/packages/html-to-slate-ast/src/index.ts
@@ -30,7 +30,7 @@ const ELEMENT_TAGS: Record<
       ...(el.hasAttribute('class') && {
         className: el.getAttribute('class'),
       }),
-      openInNewTab: Boolean(el.getAttribute('target') === '_blank'),
+      openInNewTab: true,
     };
   },
   BLOCKQUOTE: () => ({ type: 'block-quote' }),


### PR DESCRIPTION
When I use this in the same way the docs indicate it always results in '_self'. Looks like it's asking for the target value within the target itself, which will not be assigned and always return false. 

Does this make sense or am I missing something? I figured by returning true, we just always have that value and if it's deconstructed and present, will make the ternary work properly.