### PR TITLE
chore: update @braintree/sanitize-url to latest version

### DIFF
--- a/.changeset/eight-elephants-battle.md
+++ b/.changeset/eight-elephants-battle.md
@@ -1,0 +1,5 @@
+---
+'@graphcms/html-to-slate-ast': patch
+---
+
+Update @braintree/sanitize-url to fix vulnerability issue

--- a/packages/html-to-slate-ast/package.json
+++ b/packages/html-to-slate-ast/package.json
@@ -44,7 +44,7 @@
   ],
   "jest": {},
   "dependencies": {
-    "@braintree/sanitize-url": "^5.0.2",
+    "@braintree/sanitize-url": "^6.0.4",
     "@graphcms/rich-text-types": "^0.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,10 +908,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@braintree/sanitize-url@^5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-5.0.2.tgz#b23080fa35520e993a8a37a0f5bca26aa4650a48"
-  integrity sha512-NBEJlHWrhQucLhZGHtSxM2loSaNUMajC7KOYJLyfcdW/6goVoff2HoYI3bz8YCDN0wKGbxtUL0gx2dvHpvnWlw==
+"@braintree/sanitize-url@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz#923ca57e173c6b232bbbb07347b1be982f03e783"
+  integrity sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==
 
 "@changesets/apply-release-plan@^5.0.0":
   version "5.0.0"


### PR DESCRIPTION
If tests are passing, we should be good to go. There are no breaking changes apart from the vulnerability issue fixed on @braintree/sanitize-url 6.0.0.